### PR TITLE
Inicialização da tela de perguntas frequentes

### DIFF
--- a/cead/templates/cead/partials/base.html
+++ b/cead/templates/cead/partials/base.html
@@ -230,8 +230,8 @@
                 </li>
         
                 <li class="nav-item">
-                    <a class="nav-link {% if request.path == '/perguntas/' %}active{% endif %}" 
-                       href="">
+                    <a class="nav-link {% if request.resolver_match.url_name == 'perguntas_lista' %}active{% endif %}" 
+                       href="{% url 'coo:perguntas_lista' %}">
                        Perguntas
                     </a>
                 </li>

--- a/coo/forms.py
+++ b/coo/forms.py
@@ -2,7 +2,7 @@ from django import forms
 
 from cead.models import Noticia, Polo, Coordenador, Curso, Mediador, CoordenadorCurso, NoticiaCurso, CursoPolo, Mediacao, Gestor, GestorPolos, Disciplina
 
-from coo.models import Contato, Documentos
+from coo.models import Contato, Documentos, Perguntas
 
 
 class SearchForm(forms.Form):
@@ -307,6 +307,22 @@ class DocumentoForm(forms.ModelForm):
         else:
             Documentos.objects.create(
                 documentos=instance,
+            )
+
+class PerguntaForm(forms.ModelForm):
+    class Meta:
+        model = Perguntas
+        fields = ['curso','pergunta', 'resposta',]
+
+    def save(self, commit=True):
+        instance = super().save(commit=False)
+
+        if commit:
+            instance.save()
+
+        else:
+            Perguntas.objects.create(
+                perguntas=instance,
             )
 
         return instance

--- a/coo/templates/coo/pages/imagem.html
+++ b/coo/templates/coo/pages/imagem.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="pt-br">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Visualizar Imagem</title>
+</head>
+<body>
+    <h1>{{ documento.titulo }}</h1>
+    <img src="{{ documento.arquivo.url }}" alt="Imagem do Documento" style="max-width: 100%; height: auto;">
+    <br>
+    <a href="{% url 'coo:documentos_publico' %}">Voltar para a lista de documentos</a>
+</body>
+</html>

--- a/coo/templates/coo/pages/perguntas.html
+++ b/coo/templates/coo/pages/perguntas.html
@@ -1,0 +1,127 @@
+{% extends "cead/partials/base.html" %}
+
+{% load static %}
+
+{% block style %}
+    <link rel="stylesheet" href="{% static 'css/tabela.css' %}">
+    <link rel="stylesheet" href="{% static 'css/modal.css' %}">
+{% endblock style %}
+
+{% block title %} Perguntas Frequentes {% endblock title %}
+
+{% block content %}
+    
+    <main>
+
+        <nav aria-label="breadcrumb" style="color: #FF2900;">
+            <ol class="breadcrumb" style="color: #FF2900;">
+                {% for crumb in breadcrumbs %}
+                    <li class="breadcrumb-item" style="color: #FF2900;">
+                        {{ crumb.name }}
+                    </li>
+                {% endfor %}
+            </ol>
+        </nav>
+        
+        <h1 class="container d-flex justify-content-center mt-3">Perguntas Frequentes</h1>
+        
+        <div class="d-flex mx-4 gap-3 jus">
+            <form method="get" class="search_input d-flex p-0">
+                <input type="text" name="query" class="form-control" placeholder="Buscar perguntas" value="{{ query }}">
+                <button type="submit" class="p-2 ms-1 button_search">
+                    <img src="{% static 'images/icons/search.svg' %}" alt="" class="icons_action"></img>
+                </button>
+            </form>
+            <button type="button" class="btn btn-primary" data-bs-toggle="modal" data-bs-target="#modalCriarPergunta">
+                Criar
+            </button>
+        </div>
+        
+        <div class="table-responsive mx-4">
+            <table class="table table-hover mt-3 table_rounded">
+                <thead>
+                    <tr class="text-center table_header">
+                        <th>Curso</th>
+                        <th>Pergunta</th>
+                        <th>Resposta</th>
+                        <th>Arquivo</th>
+                        <th>Ação</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {% for pergunta in perguntas %}
+                    <tr>
+                        <td>{{ pergunta.curso.nome}}</td>
+                        <td>{{ pergunta.pergunta }}</td>
+                        <td>{{ pergunta.resposta }}</td>
+                        <td>{{ pergunta.arquivo }}</td>
+                        <td>
+                            <div class="icons_action d-flex justify-content-center gap-2">
+                                <button class="button_icon editar-pergunta" data-bs-toggle="modal" data-bs-target="#EditarPergunta" data-id="{{ pergunta.id }}">
+                                    <img src="{% static 'images/icons/edit.svg' %}" alt="Edit">
+                                </button>
+                                
+                                <button class="button_icon detalhar-pergunta" data-bs-toggle="modal" data-bs-target="#DetalharPergunta" data-id="{{ pergunta.id }}">
+                                    <img src="{% static 'images/icons/visibility.svg' %}" alt="Ver detalhes">
+                                </button>
+                                
+                                <button class="button_icon button_delete" data-bs-toggle="modal" data-bs-target="#ExcluirPergunta" data-id="{{ pergunta.id }}">
+                                    <img src="{% static 'images/icons/delete.svg' %}" alt="Delete"></img>
+                                </button>
+                            </div>
+                        </td>
+                    </tr>
+                    {% empty %}
+                        <tr>
+                            <td colspan="4">Nenhuma pergunta encontrada.</td>
+                        </tr>     
+                    {% endfor %}
+                </tbody>
+            </table>
+        </div>
+
+        
+        <nav aria-label="Page navigation">
+            <ul class="pagination justify-content-center">
+                {% if perguntas.has_previous %}
+                    <li class="page-item">
+                        <a class="page-link" href="?page=1">&laquo;</a>
+                    </li>
+                    <li class="page-item"> 
+                        <a class="page-link" href="?page={{ perguntas.previous_page_number }}">Anterior</a>
+                    </li>
+                {% else %}
+                    <li class="page-item disabled">
+                        <a class="page-link" href="#">&laquo;</a>
+                    </li>
+                    <li class="page-item disabled"> 
+                        <a class="page-link" href="#">Anterior</a>
+                    </li>
+                {% endif %}
+        
+                <li class="page-item">
+                    <a class="page-link">{{ perguntas.number }}</a>
+                </li>
+        
+                {% if perguntas.has_next %}
+                    <li class="page-item">
+                        <a class="page-link" href="?page={{ perguntas.next_page_number }}">Próxima</a>
+                    </li>
+                    <li class="page-item">
+                        <a class="page-link" href="?page={{ perguntas.paginator.num_pages }}">&raquo;</a>
+                    </li>
+                {% else %}
+                    <li class="page-item disabled">
+                        <a class="page-link" href="#">Próxima</a>
+                    </li>
+                    <li class="page-item disabled">
+                        <a class="page-link" href="#">&raquo;</a>
+                    </li>
+                {% endif %}
+            </ul>
+        </nav>
+        
+        {% include "coo/partials/modais_perguntas.html" %}
+    </main>
+
+{% endblock content %}

--- a/coo/templates/coo/pages/teste_documentos.html
+++ b/coo/templates/coo/pages/teste_documentos.html
@@ -23,12 +23,17 @@
             <tr>
                 <td>{{ documento.titulo }}</td>
                 <td>{{ documento.descricao }}</td>
+
+
                 <td>
                     {% if documento.arquivo %}
                         {% if documento.arquivo.url|lower|slice:"-4:" == ".png" or documento.arquivo.url|lower|slice:"-4:" == ".jpg" or documento.arquivo.url|lower|slice:"-5:" == ".jpeg" or documento.arquivo.url|lower|slice:"-4:" == ".gif" %}
-                            <img src="{{ documento.arquivo.url }}" height="50" alt="Prévia da imagem">
+                            <!-- Adicionando link para visualizar a imagem -->
+                            <a href="{% url 'coo:visualizar_imagem' documento.id %}">
+                                <img src="{{ documento.arquivo.url }}" height="200" alt="Visualizar imagem">
+                            </a>
                         {% else %}
-                            <a href="{{ documento.arquivo.url }}" target="_blank">Baixar Arquivo</a>
+                            <a href="{% url 'coo:visualizar_documento' documento.id %}" target="_blank">Visualizar Documento</a>
                         {% endif %}
                     {% else %}
                         Nenhum arquivo disponível

--- a/coo/templates/coo/partials/modais_documentos.html
+++ b/coo/templates/coo/partials/modais_documentos.html
@@ -275,7 +275,7 @@ $(document).ready(function() {
         // Envia a requisição AJAX
         $.ajax({
             type: 'POST',
-            url: `/coo/editar_documento/${documentoId}/?curso=${cursoId}`,
+            url: `/coo/editar_documento/${documentoId}/?curso=${cursoId}`,  
             data: formData,
             processData: false,
             contentType: false,

--- a/coo/templates/coo/partials/modais_perguntas.html
+++ b/coo/templates/coo/partials/modais_perguntas.html
@@ -1,0 +1,73 @@
+{% load static %}
+
+<!-- Criar -->
+<div class="modal fade" id="modalCriarPergunta" tabindex="-1" aria-labelledby="modalCriarPerguntaLabel" aria-hidden="true">
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <div class="modal-header justify-content-between">
+                <span></span>
+                <h5 class="modal-title" id="modalCriarPerguntaLabel">Pergunta</h5>
+                <button type="button" class="button_close" data-bs-dismiss="modal" aria-label="Close">
+                    <img src="{% static 'images/icons/close.svg' %}" alt="" class="icons_action"></img>
+                </button>
+            </div>
+            <div class="modal-body">
+                <form id="formCriarPergunta" method="post" action="{% url 'coo:perguntas_lista' %}">
+                    {% csrf_token %}
+                    
+                    <div class="input">
+                        {{ form.as_p }}
+                    </div>
+                    <div class="d-flex justify-content-center">
+                        <button type="submit" class="btn d-flex justify-content-center">Salvar</button>
+                    </div>
+                </form>
+            </div>
+        </div>
+    </div>
+</div>
+
+
+
+<script>
+
+$(document).ready(function() {
+    
+    // Função para criar pergunta
+    $('#formCriarPergunta').on('submit', function(e) {
+        e.preventDefault();
+        $.ajax({
+            type: 'POST',
+            url: "{% url 'coo:criar_pergunta' %}",
+            data: $(this).serialize(),
+            success: function(response) {
+                if (response.success) {
+                    alert("Pergunta criada com sucesso!");
+                    location.reload();
+                } else {
+                    alert("Erro ao criar pergunta: " + JSON.stringify(response.errors));
+                }
+            }
+        });
+    });
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+});
+
+
+</script>

--- a/coo/urls.py
+++ b/coo/urls.py
@@ -45,6 +45,8 @@ urlpatterns = [
 
 #documentos_publicos
     path('documentos_publico/', views.documentos_publico, name='documentos_publico'),
+    path('documento/<int:documento_id>/', views.visualizar_documento, name='visualizar_documento'),
+    path('coo/visualizar_imagem/<int:id>/', views.visualizar_imagem, name='visualizar_imagem'),
 
 
 #documento
@@ -53,6 +55,14 @@ urlpatterns = [
     path('editar_documento/<int:documento_id>/', views.editar_documento, name='editar_documento'),
     path('excluir_documento/<int:documento_id>/', views.excluir_documento, name='excluir_documento'),
     path('detalhar_documento/<int:documento_id>/', views.detalhar_documento, name='detalhar_documento'),
+
+
+#perguntas
+    path('perguntas/', views.perguntas_lista, name="perguntas_lista"),
+    path('criar_pergunta/', views.criar_pergunta, name='criar_pergunta'),
+    path('editar_pergunta/<int:pergunta_id>/', views.editar_pergunta, name='editar_pergunta'),
+    path('excluir_pergunta/<int:pergunta_id>/', views.excluir_pergunta, name='excluir_pergunta'),
+    path('detalhar_pergunta/<int:pergunta_id>/', views.detalhar_pergunta, name='detalhar_pergunta'),
 
 
 #teste


### PR DESCRIPTION
Hoje, começamos trabalhando na parte de documentos, onde fizemos ajustes para exibir a lista de documentos, permitindo visualizar e baixar arquivos. Também configurei os links de ação para editar, excluir e ver detalhes dos documentos.
Depois, seguimos para a parte de perguntas frequentes . Alterei as URLs e o template para ajustar a exibição da lista de perguntas, com funcionalidades de busca, criação, edição, exclusão e visualização de detalhes. Durante a implementação do modal para criar perguntas, identifiquei um problema com os campos do formulário, que ainda precisa ser corrigido.